### PR TITLE
Fix MappedEnum value handling

### DIFF
--- a/src/drjutils/common/types/enums/enum_utils.py
+++ b/src/drjutils/common/types/enums/enum_utils.py
@@ -708,10 +708,12 @@ def make_enum_and_str_rep_dicts(
     str_rep_to_enum_dict:  StrRepToEnumDict[EnumType]  = {}
 
     for enum in enum_class:
-        if isinstance(enum.value, Sequence) and isinstance(next(iter(enum.value), None), str):
-            str_reps = enum.value
+        if hasattr(enum, "_str_reps"):
+            str_reps = enum._str_reps  # type: ignore[attr-defined]
         elif isinstance(enum.value, str):
-            str_reps = (enum.name,)
+            str_reps = (enum.value,)
+        elif isinstance(enum.value, Sequence) and isinstance(next(iter(enum.value), None), str):
+            str_reps = tuple(enum.value)
         else:
             raise AssertionError(
                 f"Enum {enum!r} has an invalid value type: {type(enum.value)!r}. "

--- a/src/drjutils/common/types/enums/mapped_enum.py
+++ b/src/drjutils/common/types/enums/mapped_enum.py
@@ -106,7 +106,7 @@ class MappedEnum(Enum):
     _STRINGS_TO_ENUMS: StrRepToEnumDict[Self]
     """Mapping of all string representations to their corresponding Enum members."""
 
-    def __new__(cls, value: StrRepOrReps) -> Self:
+    def __new__(cls, *value: str) -> Self:
         """
         Create a new instance of the enum with the given string representations.
 
@@ -122,14 +122,13 @@ class MappedEnum(Enum):
         Raises:
             ValueError: If the value is empty or does not contain valid strings.
         """
-        assert_str_reps_valid(value, Self)
+        reps = value
+        if len(reps) == 1 and isinstance(reps[0], (tuple, list)):
+            reps = tuple(reps[0])
+
+        assert_str_reps_valid(reps, Self)
 
         obj = object.__new__(cls)
-
-        if isinstance(value, str):
-            reps = (value,)
-        else:
-            reps = tuple(value)
 
         obj._value_ = reps[0]
         obj._str_reps = reps


### PR DESCRIPTION
## Summary
- fix `MappedEnum.__new__` to handle unpacked tuple values
- handle `_str_reps` when generating enum mapping

## Testing
- `pytest tests/drjutils/common/test_types/test_mapped_enum.py -q`
- `pytest -q` *(fails: NameError: name 'is_std_interval_str' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6851e8136eb483289c86d0b0161118ab