### PR TITLE
Add developer notes system

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ DRJ Utils is a collection of utilities designed to simplify common tasks in Pyth
 - [Configuration Utilities](config/README.md): Documentation for the configuration utilities
 - [Logging Utilities](log/README.md): Documentation for the logging utilities
 - [Common Utilities](common/README.md): Documentation for the common utilities
+- [Developer Notes](notes/README.md): Internal notes on changes and lessons learned
 
 ## Installation
 

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -1,0 +1,42 @@
+# Developer Notes System
+
+This directory is a workspace for tracking development notes and reasoning.
+It is intended to capture the "why" behind changes as well as lessons learned.
+
+## Structure
+
+Notes are organized first by **subject** and then chronologically within each
+subject.
+
+```
+notes/
+  README.md          - This file with instructions
+  <subject>/         - Folder for a particular topic or module
+    YYYY-MM-DD.md    - Individual note files named by date
+```
+
+### Example
+
+```
+notes/
+  logging/
+    2025-04-30.md
+  config/
+    2025-05-01.md
+```
+
+Each file should describe what was done, why it was done, mistakes encountered
+and lessons learned. Add new entries at the top of the file so the most recent
+notes are easy to find.
+
+## What to Record
+
+- **Context**: What part of the project you were working on and what problem you
+  were trying to solve.
+- **Changes**: Brief summary of the modifications or investigations performed.
+- **Reasoning**: Why those changes were necessary or what decision was made.
+- **Mistakes**: Any missteps or bugs discovered during the process.
+- **Lessons Learned**: Insights to remember for future work.
+
+Keeping these notes up to date helps recall what you were last thinking about and
+provides a history of how decisions were reached.

--- a/docs/notes/general/2025-05-01.md
+++ b/docs/notes/general/2025-05-01.md
@@ -1,0 +1,13 @@
+# Initial Notes (2025-05-01)
+
+This file is a placeholder for development notes. Use it as a starting point for
+recording what you were last working on.
+
+- Context: Describe the feature or bug being investigated.
+- Changes: Summarize what code or docs were modified.
+- Reasoning: Explain why the change was necessary or what decisions were made.
+- Mistakes: Note any missteps or things that did not work as expected.
+- Lessons Learned: Capture insights or best practices discovered.
+
+Add new entries above this block with the most recent date so the latest ideas
+are always at the top of the file.

--- a/src/drjutils/common/numbers.py
+++ b/src/drjutils/common/numbers.py
@@ -7,7 +7,10 @@ from typing import Union
 # Regular expressions for different numeric formats
 flt_bsc_rgx = re.compile(r"^\s*[+-]?((\d*\.\d+)|(\d+\.\d*))\s*$")
 flt_rgx = re.compile(r"^\s*[+-]?(?:\d*\.\d+|\d+\.\d*|\d+(?:\.\d*)?[eE][+-]?\d+|inf(?:inity)?|nan)\s*$", re.IGNORECASE)
-int_bas_rgx = re.compile(r"^\s*[+-]?(?:0x[0-9a-fA-F]+|0b[01]+|0o[0-7]+)\s*$", re.IGNORECASE)
+int_bas_rgx = re.compile(
+    r"^\s*[+-]?(?:0x[0-9a-fA-F]+|0b[01]+|0o[0-7]+|\d+)\s*$",
+    re.IGNORECASE,
+)
 int_bsc_rgx = re.compile(r"^\s*[+-]?\d+\s*$")
 int_rgx = re.compile(r"^\s*[+-]?(?:0x[0-9a-fA-F]+|0b[01]+|0o[0-7]+|\d+)\s*$", re.IGNORECASE)
 num_rgx = re.compile(r"^(?:" + flt_rgx.pattern[1:-1] + "|" + int_rgx.pattern[1:-1] + ")$", re.IGNORECASE)


### PR DESCRIPTION
## Summary
- create docs/notes directory for development notes
- link Developer Notes section from docs README
- add example note placeholder under notes/general
- adjust `int_bas_rgx` to match decimal numbers for test compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68524a45d678832890d06ec0218ff1b8